### PR TITLE
Fix ValueError: too many values to unpack issue in obo copy --replace

### DIFF
--- a/obo/obo.py
+++ b/obo/obo.py
@@ -426,7 +426,7 @@ class OboObject:
         headers['x-amz-copy-source'] = src_str
         headers['x-amz-metadata-directive'] = 'REPLACE'
 
-        for (h, v) in k.metadata:
+        for (h, v) in k.metadata.items():
             headers[h] = v;
 
         if k.content_type:


### PR DESCRIPTION
Fix ValueError: too many values to unpack issue in obo copy --replace

obo copy test-bucket/test-bucket1/test1/cirros.raw test-bucket/test-bucket1/test1/cirros.raw --replace
Traceback (most recent call last):
  File "/usr/bin/obo", line 11, in <module>
    load_entry_point('obo==0.0.1', 'console_scripts', 'obo')()
  File "build/bdist.linux-x86_64/egg/obo/obo.py", line 969, in main
  File "build/bdist.linux-x86_64/egg/obo/obo.py", line 936, in copy
  File "build/bdist.linux-x86_64/egg/obo/obo.py", line 429, in replace
ValueError: too many values to unpack

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>